### PR TITLE
feat: enhance sdk-python and docs with document management endpoints

### DIFF
--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -189,3 +189,196 @@ response = client.recall_with_llm(
 )
 print(response.text)
 ```
+
+### `insert_document`
+
+Ingest a single memory document. Sends `POST /v1/memory/documents`.
+
+```python
+client.insert_document(
+    title="Doc title",
+    content="Doc content",
+    namespace="documents",
+    source_type="doc",  # optional
+    metadata={"source": "example"},  # optional
+    document_id="optional-document-id",  # optional
+)
+```
+
+### `insert_documents_batch`
+
+Ingest multiple documents in one call. Sends `POST /v1/memory/documents/batch`.
+
+```python
+client.insert_documents_batch(
+    items=[
+        {
+            "title": "Doc A",
+            "content": "Content A",
+            "namespace": "documents",
+            "documentId": "doc-a-id",  # optional
+        },
+        {
+            "title": "Doc B",
+            "content": "Content B",
+            "namespace": "documents",
+            "documentId": "doc-b-id",  # optional
+        },
+    ]
+)
+```
+
+### `list_documents`
+
+List ingested documents. Sends `GET /v1/memory/documents`.
+
+```python
+client.list_documents(namespace="documents", limit=10, offset=0)
+```
+
+### `get_document`
+
+Get document details. Sends `GET /v1/memory/documents/:documentId`.
+
+```python
+client.get_document(document_id="doc-a-id", namespace="documents")
+```
+
+### `delete_document`
+
+Delete a document. Sends `DELETE /v1/memory/documents/:documentId`.
+
+```python
+client.delete_document(document_id="doc-a-id", namespace="documents")
+```
+
+### `query_memory_context`
+
+Query memory context via the mirrored endpoint. Sends `POST /v1/memory/queries`.
+
+```python
+client.query_memory_context(
+    query="What did we store?",
+    namespace="documents",
+    include_references=True,
+    max_chunks=5,
+    document_ids=["doc-a-id"],  # optional
+)
+```
+
+### `chat_memory_context`
+
+Chat with memory context. Sends `POST /v1/memory/conversations`.
+
+```python
+client.chat_memory_context(
+    messages=[{"role": "user", "content": "Summarize the stored docs"}],
+    temperature=0,
+    max_tokens=256,
+)
+```
+
+### `record_interactions`
+
+Record interaction signals. Sends `POST /v1/memory/interactions`.
+
+```python
+client.record_interactions(
+    namespace="documents",
+    entity_names=["ENTITY-A", "ENTITY-B"],
+    description="Recorded via sdk-python example",
+    interaction_level="engage",
+)
+```
+
+### `recall_thoughts`
+
+Generate reflective thoughts. Sends `POST /v1/memory/memories/thoughts`.
+
+```python
+client.recall_thoughts(namespace="documents", max_chunks=5)
+```
+
+### `sync_memory` (optional / backend-specific)
+
+Sync OpenClaw memory files. Sends `POST /v1/memory/sync`.
+
+```python
+client.sync_memory(
+    workspace_id="workspace-id",
+    agent_id="agent-id",
+    source="startup",  # optional
+    files=[
+        {
+            "file_path": "example.txt",
+            "content": "file contents",
+            "timestamp": "1700000000",
+            "hash": "sha256-hex",
+        }
+    ],
+)
+```
+
+### `chat_memory`
+
+Chat with DeltaNet memory cache. Sends `POST /v1/memory/chat`.
+
+```python
+client.chat_memory(
+    messages=[{"role": "user", "content": "Hello"}],
+    temperature=0.2,
+    max_tokens=256,
+)
+```
+
+### `interact_memory`
+
+Record entity interactions in the core backend. Sends `POST /v1/memory/interact`.
+
+```python
+client.interact_memory(
+    namespace="documents",
+    entity_names=["ENTITY-A", "ENTITY-B"],
+    description="Recorded by sdk-python example",
+    interaction_level="engage",
+)
+```
+
+### `recall_memory_master`
+
+Recall context from the Master node. Sends `POST /v1/memory/recall`.
+
+Note: this is different from `recall_memory(...)` which uses the RAG query endpoint (`POST /v1/memory/query`).
+
+```python
+ctx = client.recall_memory_master(namespace="documents", max_chunks=5)
+print(ctx.context)
+```
+
+### `recall_memories`
+
+Recall memories from the Ebbinghaus bank. Sends `POST /v1/memory/memories/recall`.
+
+```python
+client.recall_memories(
+    namespace="documents",
+    top_k=5,
+    min_retention=0,
+)
+```
+
+### `get_graph_snapshot` (optional / backend-specific)
+
+Fetch graph topology snapshot. Sends `GET /v1/memory/admin/graph-snapshot`.
+
+```python
+client.get_graph_snapshot(namespace="documents", mode="latest_chunks", limit=10, seed_limit=3)
+```
+
+### `get_ingestion_job` (optional)
+
+Get ingestion job status. Sends `GET /v1/memory/ingestion/jobs/:jobId`.
+
+```python
+client.get_ingestion_job(job_id="some-job-id")
+```

--- a/packages/sdk-python/example.py
+++ b/packages/sdk-python/example.py
@@ -7,6 +7,7 @@ Optional: set TINYHUMANSAI_LOG_LEVEL=DEBUG to print outbound API requests.
 """
 
 import logging
+import hashlib
 import os
 import time
 
@@ -18,7 +19,10 @@ if os.environ.get("TINYHUMANSAI_LOG_LEVEL") and not logging.getLogger().handlers
 
 import tinyhumansai as api
 
-client = api.TinyHumanMemoryClient(os.environ["TINYHUMANS_TOKEN"])
+client = api.TinyHumanMemoryClient(
+    os.environ["TINYHUMANS_TOKEN"],
+    model_id=os.environ.get("TINYHUMANS_MODEL_ID", "neocortex-mk1"),
+)
 
 # Ingest (upsert) a single memory
 result = client.ingest_memory(
@@ -67,3 +71,221 @@ print(response.text)
 # Delete all memory in namespace
 # The current API exposes namespace-wide delete, not key-scoped delete.
 client.delete_memory(namespace="preferences", delete_all=True)
+
+# ---------------------------------------------------------------------------
+# Documents & mirrored endpoints (aligned with the TypeScript SDK)
+# ---------------------------------------------------------------------------
+
+docs_ns = f"python-e2e-docs-{int(time.time())}"
+
+document_id_single = f"py-doc-single-{int(time.time())}"
+document_id_batch_0 = f"py-doc-batch-0-{int(time.time())}"
+document_id_batch_1 = f"py-doc-batch-1-{int(time.time())}"
+
+print("\n--- Documents endpoints (new) ---")
+
+try:
+    single_doc = client.insert_document(
+        title="Python E2E Doc (single)",
+        content="Content stored by the Python SDK example (single).",
+        namespace=docs_ns,
+        source_type="doc",
+        metadata={"source": "sdk-python-example", "variant": "single"},
+        document_id=document_id_single,
+    )
+    print("insert_document:", single_doc)
+except Exception as e:
+    print("insert_document failed:", e)
+
+try:
+    batch_res = client.insert_documents_batch(
+        items=[
+            {
+                "title": "Python E2E Doc (batch 0)",
+                "content": "Content stored by the Python SDK example (batch 0).",
+                "namespace": docs_ns,
+                "sourceType": "doc",
+                "metadata": {"source": "sdk-python-example", "variant": "batch-0"},
+                "documentId": document_id_batch_0,
+            },
+            {
+                "title": "Python E2E Doc (batch 1)",
+                "content": "Content stored by the Python SDK example (batch 1).",
+                "namespace": docs_ns,
+                "sourceType": "doc",
+                "metadata": {"source": "sdk-python-example", "variant": "batch-1"},
+                "documentId": document_id_batch_1,
+            },
+        ]
+    )
+    print("insert_documents_batch:", batch_res)
+except Exception as e:
+    print("insert_documents_batch failed:", e)
+
+try:
+    list_res = client.list_documents(namespace=docs_ns, limit=10, offset=0)
+    print("list_documents:", list_res)
+except Exception as e:
+    print("list_documents failed:", e)
+
+try:
+    get_res = client.get_document(document_id=document_id_single, namespace=docs_ns)
+    print("get_document:", get_res)
+except Exception as e:
+    print("get_document failed:", e)
+
+try:
+    query_ctx_res = client.query_memory_context(
+        query="What content did the Python SDK example store?",
+        namespace=docs_ns,
+        include_references=True,
+        max_chunks=5,
+        document_ids=[document_id_single],
+    )
+    print("query_memory_context:", query_ctx_res)
+except Exception as e:
+    print("query_memory_context failed:", e)
+
+try:
+    chat_ctx_res = client.chat_memory_context(
+        messages=[
+            {
+                "role": "user",
+                "content": "Using the stored memory, summarize what the single document contains.",
+            }
+        ],
+        temperature=0,
+        max_tokens=256,
+    )
+    print("chat_memory_context:", chat_ctx_res)
+except Exception as e:
+    print("chat_memory_context failed:", e)
+
+try:
+    interact_res = client.record_interactions(
+        namespace=docs_ns,
+        entity_names=["PY-ENTITY-A", "PY-ENTITY-B"],
+        description="Recorded by sdk-python example",
+        interaction_level="engage",
+    )
+    print("record_interactions:", interact_res)
+except Exception as e:
+    print("record_interactions failed:", e)
+
+try:
+    thoughts_res = client.recall_thoughts(namespace=docs_ns, max_chunks=5)
+    print("recall_thoughts:", thoughts_res)
+except Exception as e:
+    print("recall_thoughts failed:", e)
+
+try:
+    # Optional: this endpoint may be backend-specific.
+    graph_snapshot = client.get_graph_snapshot(
+        namespace=docs_ns,
+        mode="latest_chunks",
+        limit=10,
+        seed_limit=3,
+    )
+    print("get_graph_snapshot:", graph_snapshot)
+except Exception as e:
+    print("get_graph_snapshot failed (optional):", e)
+
+print("\n--- Core endpoints (new) ---")
+
+try:
+    workspace_id = os.environ.get("TINYHUMANS_WORKSPACE_ID")
+    agent_id = os.environ.get("TINYHUMANS_AGENT_ID")
+    if workspace_id and agent_id:
+        sync_content = "File sync content from sdk-python example."
+        sync_hash = hashlib.sha256(sync_content.encode("utf-8")).hexdigest()
+        sync_res = client.sync_memory(
+            workspace_id=workspace_id,
+            agent_id=agent_id,
+            source="startup",
+            files=[
+                {
+                    "file_path": "example.txt",
+                    "content": sync_content,
+                    "timestamp": str(int(time.time())),
+                    "hash": sync_hash,
+                }
+            ],
+        )
+        print("sync_memory:", sync_res)
+    else:
+        print(
+            "sync_memory skipped (set TINYHUMANS_WORKSPACE_ID and TINYHUMANS_AGENT_ID)."
+        )
+except Exception as e:
+    print("sync_memory failed (optional):", e)
+
+try:
+    chat_res = client.chat_memory(
+        messages=[
+            {
+                "role": "user",
+                "content": "Summarize the single document that was stored earlier.",
+            }
+        ],
+        temperature=0,
+        max_tokens=256,
+    )
+    print("chat_memory:", chat_res)
+except Exception as e:
+    print("chat_memory failed (optional):", e)
+
+try:
+    interact_res = client.interact_memory(
+        namespace=docs_ns,
+        entity_names=["PY-ENTITY-A", "PY-ENTITY-B"],
+        description="Recorded by sdk-python example (interactMemory endpoint).",
+        interaction_level="engage",
+        timestamp=time.time(),
+    )
+    print("interact_memory:", interact_res)
+except Exception as e:
+    print("interact_memory failed (optional):", e)
+
+try:
+    master_ctx = client.recall_memory_master(namespace=docs_ns, max_chunks=5)
+    print("recall_memory_master.context:", master_ctx.context)
+except Exception as e:
+    print("recall_memory_master failed (optional):", e)
+
+try:
+    memories_res = client.recall_memories(namespace=docs_ns, top_k=5, min_retention=0)
+    print("recall_memories:", memories_res)
+except Exception as e:
+    print("recall_memories failed (optional):", e)
+
+try:
+    # Optional: if insert returned jobId fields.
+    job_id = None
+    if isinstance(single_doc, dict):
+        job_id = single_doc.get("jobId")
+    if not job_id and isinstance(batch_res, dict):
+        job_id = batch_res.get("jobId")
+    if job_id:
+        ingestion_job = client.get_ingestion_job(job_id=job_id)
+        print("get_ingestion_job:", ingestion_job)
+    else:
+        print("get_ingestion_job skipped (no jobId returned).")
+except Exception as e:
+    print("get_ingestion_job failed (optional):", e)
+
+try:
+    client.delete_document(document_id=document_id_single, namespace=docs_ns)
+except Exception as e:
+    print("delete_document (single) failed:", e)
+
+for doc_id in [document_id_batch_0, document_id_batch_1]:
+    try:
+        client.delete_document(document_id=doc_id, namespace=docs_ns)
+    except Exception as e:
+        print(f"delete_document ({doc_id}) failed:", e)
+
+# Cleanup: delete entire namespace (safe fallback).
+try:
+    client.delete_memory(namespace=docs_ns, delete_all=True)
+except Exception as e:
+    print("cleanup delete_memory failed:", e)

--- a/packages/sdk-python/tinyhumansai/client.py
+++ b/packages/sdk-python/tinyhumansai/client.py
@@ -6,6 +6,7 @@ import logging
 import os
 import time
 from typing import Any, Optional, Sequence, Union
+from urllib.parse import quote
 
 import httpx
 
@@ -28,6 +29,23 @@ logger = logging.getLogger("tinyhumansai")
 INSERT_PATH = "/v1/memory/insert"
 QUERY_PATH = "/v1/memory/query"
 DELETE_PATH = "/v1/memory/admin/delete"
+
+# --- Newer endpoints (documents, mirrored context, admin graph, etc.) ---
+SYNC_PATH = "/v1/memory/sync"
+CHAT_PATH = "/v1/memory/chat"
+INTERACT_PATH = "/v1/memory/interact"
+RECALL_MASTER_PATH = "/v1/memory/recall"
+RECALL_MEMORIES_PATH = "/v1/memory/memories/recall"
+
+DOCUMENTS_INSERT_PATH = "/v1/memory/documents"
+DOCUMENTS_BATCH_PATH = "/v1/memory/documents/batch"
+DOCUMENTS_LIST_PATH = "/v1/memory/documents"
+DOCUMENTS_GRAPH_SNAPSHOT_PATH = "/v1/memory/admin/graph-snapshot"
+MEMORY_QUERIES_PATH = "/v1/memory/queries"
+MEMORY_CONVERSATIONS_PATH = "/v1/memory/conversations"
+MEMORY_INTERACTIONS_PATH = "/v1/memory/interactions"
+MEMORY_THOUGHTS_PATH = "/v1/memory/memories/thoughts"
+INGESTION_JOB_PATH_PREFIX = "/v1/memory/ingestion/jobs"
 
 
 def _validate_timestamp(value: Optional[float], name: str) -> None:
@@ -412,6 +430,465 @@ class TinyHumanMemoryClient:
             url=url,
         )
 
+    def sync_memory(
+        self,
+        *,
+        workspace_id: str,
+        agent_id: str,
+        files: Sequence[dict[str, Any]],
+        source: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Sync OpenClaw memory files (TS: syncMemory).
+
+        Sends POST /v1/memory/sync.
+        """
+        if not workspace_id or not isinstance(workspace_id, str):
+            raise ValueError("workspace_id is required and must be a string")
+        if not agent_id or not isinstance(agent_id, str):
+            raise ValueError("agent_id is required and must be a string")
+        if not files or not isinstance(files, (list, tuple)):
+            raise ValueError("files must be a non-empty list of file objects")
+
+        normalized_files: list[dict[str, Any]] = []
+        for f in files:
+            file_path = f.get("filePath", f.get("file_path"))
+            content = f.get("content")
+            timestamp = f.get("timestamp")
+            hash_value = f.get("hash")
+
+            if not file_path or not isinstance(file_path, str):
+                raise ValueError("each file requires filePath/file_path (string)")
+            if not content or not isinstance(content, str):
+                raise ValueError("each file requires content (string)")
+            if timestamp is None or not isinstance(timestamp, (str, int, float)):
+                raise ValueError("each file requires timestamp (string|number)")
+            if not hash_value or not isinstance(hash_value, str):
+                raise ValueError("each file requires hash (string)")
+
+            normalized_files.append(
+                {
+                    "filePath": file_path,
+                    "content": content,
+                    # backend expects string-ish timestamps; keep original type if str,
+                    # otherwise stringify numeric timestamps.
+                    "timestamp": timestamp if isinstance(timestamp, str) else str(timestamp),
+                    "hash": hash_value,
+                }
+            )
+
+        body: dict[str, Any] = {
+            "workspaceId": workspace_id,
+            "agentId": agent_id,
+            "files": normalized_files,
+        }
+        if source is not None:
+            body["source"] = source
+
+        return self._send("POST", SYNC_PATH, body)
+
+    def chat_memory(
+        self,
+        *,
+        messages: Sequence[dict[str, Any]],
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+    ) -> dict[str, Any]:
+        """Chat with memory context (TS: chatMemory).
+
+        Sends POST /v1/memory/chat.
+        """
+        if not messages or not isinstance(messages, (list, tuple)):
+            raise ValueError("messages must be a non-empty list of {role, content} dicts")
+        for m in messages:
+            if not isinstance(m, dict):
+                raise ValueError("messages must be dictionaries")
+            if not isinstance(m.get("role"), str) or not m.get("role"):
+                raise ValueError("each message requires role (string)")
+            if not isinstance(m.get("content"), str) or not m.get("content"):
+                raise ValueError("each message requires content (string)")
+
+        body: dict[str, Any] = {"messages": list(messages)}
+        if temperature is not None:
+            body["temperature"] = temperature
+        if max_tokens is not None:
+            body["maxTokens"] = max_tokens
+
+        return self._send("POST", CHAT_PATH, body)
+
+    def interact_memory(
+        self,
+        *,
+        namespace: str,
+        entity_names: Sequence[str],
+        description: Optional[str] = None,
+        interaction_level: Optional[str] = None,
+        interaction_levels: Optional[Sequence[str]] = None,
+        timestamp: Optional[float] = None,
+    ) -> dict[str, Any]:
+        """Record entity interaction signals (TS: interactMemory).
+
+        Sends POST /v1/memory/interact.
+        """
+        if not namespace or not isinstance(namespace, str):
+            raise ValueError("namespace is required and must be a string")
+        if not entity_names or not isinstance(entity_names, (list, tuple)):
+            raise ValueError("entity_names must be a non-empty list of strings")
+
+        body: dict[str, Any] = {"namespace": namespace, "entityNames": list(entity_names)}
+        if description is not None:
+            body["description"] = description
+        if interaction_level is not None:
+            body["interactionLevel"] = interaction_level
+        if interaction_levels is not None:
+            body["interactionLevels"] = list(interaction_levels)
+        if timestamp is not None:
+            body["timestamp"] = timestamp
+
+        return self._send("POST", INTERACT_PATH, body)
+
+    def recall_memory_master(
+        self,
+        *,
+        namespace: str,
+        max_chunks: Optional[int] = None,
+    ) -> GetContextResponse:
+        """Recall context from the master node (TS: recallMemory).
+
+        Sends POST /v1/memory/recall and parses returned context chunks
+        into the same GetContextResponse shape as recall_memory().
+        """
+        if not namespace or not isinstance(namespace, str):
+            raise ValueError("namespace is required and must be a string")
+        if max_chunks is not None and (not isinstance(max_chunks, int) or max_chunks < 1):
+            raise ValueError("max_chunks must be an integer >= 1")
+
+        body: dict[str, Any] = {"namespace": namespace}
+        if max_chunks is not None:
+            body["maxChunks"] = max_chunks
+
+        data = self._send("POST", RECALL_MASTER_PATH, body)
+        items = self._extract_read_items(data, namespace)
+        context = self._extract_context_string(data, items)
+        return GetContextResponse(context=context, items=items, count=len(items))
+
+    def recall_memories(
+        self,
+        *,
+        namespace: Optional[str] = None,
+        top_k: Optional[float] = None,
+        min_retention: Optional[float] = None,
+        as_of: Optional[float] = None,
+    ) -> dict[str, Any]:
+        """Recall memories from Ebbinghaus bank (TS: recallMemories).
+
+        Sends POST /v1/memory/memories/recall.
+        Returns raw backend `data` dict.
+        """
+        body: dict[str, Any] = {}
+        if namespace is not None:
+            if not isinstance(namespace, str) or not namespace:
+                raise ValueError("namespace must be a non-empty string")
+            body["namespace"] = namespace
+
+        if top_k is not None:
+            if not isinstance(top_k, (int, float)) or not float(top_k) or float(top_k) <= 0:
+                raise ValueError("top_k must be a positive number")
+            body["topK"] = top_k
+
+        if min_retention is not None:
+            if not isinstance(min_retention, (int, float)) or float(min_retention) < 0:
+                raise ValueError("min_retention must be a non-negative number")
+            body["minRetention"] = min_retention
+
+        if as_of is not None:
+            body["asOf"] = as_of
+
+        return self._send("POST", RECALL_MEMORIES_PATH, body)
+
+    # ------------------------------------------------------------------
+    # Documents & mirrored endpoints (aligned with TypeScript SDK)
+    # ------------------------------------------------------------------
+
+    def insert_document(
+        self,
+        *,
+        title: str,
+        content: str,
+        namespace: str,
+        source_type: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
+        priority: Optional[str] = None,
+        created_at: Optional[float] = None,
+        updated_at: Optional[float] = None,
+        document_id: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Ingest a single document into the documents backend."""
+        if not title or not isinstance(title, str):
+            raise ValueError("title is required and must be a string")
+        if not content or not isinstance(content, str):
+            raise ValueError("content is required and must be a string")
+        if not namespace or not isinstance(namespace, str):
+            raise ValueError("namespace is required and must be a string")
+
+        _validate_timestamps(created_at, updated_at)
+
+        body: dict[str, Any] = {
+            "title": title,
+            "content": content,
+            "namespace": namespace,
+        }
+        if source_type is not None:
+            body["sourceType"] = source_type
+        if metadata is not None:
+            body["metadata"] = metadata
+        if priority is not None:
+            body["priority"] = priority
+        if created_at is not None:
+            body["createdAt"] = created_at
+        if updated_at is not None:
+            body["updatedAt"] = updated_at
+        if document_id is not None:
+            body["documentId"] = document_id
+
+        return self._send("POST", DOCUMENTS_INSERT_PATH, body)
+
+    def insert_documents_batch(
+        self,
+        *,
+        items: Sequence[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Ingest multiple documents in one batch call."""
+        if not items:
+            raise ValueError("items must be a non-empty list")
+
+        normalized_items: list[dict[str, Any]] = []
+        for item in items:
+            title = item.get("title")
+            content = item.get("content")
+            namespace = item.get("namespace")
+            if not isinstance(title, str) or not title:
+                raise ValueError("each item requires string 'title'")
+            if not isinstance(content, str) or not content:
+                raise ValueError("each item requires string 'content'")
+            if not isinstance(namespace, str) or not namespace:
+                raise ValueError("each item requires string 'namespace'")
+
+            created_at = item.get("createdAt", item.get("created_at"))
+            updated_at = item.get("updatedAt", item.get("updated_at"))
+            _validate_timestamps(created_at, updated_at)
+
+            body_item: dict[str, Any] = {
+                "title": title,
+                "content": content,
+                "namespace": namespace,
+            }
+            if "sourceType" in item or "source_type" in item:
+                body_item["sourceType"] = item.get("sourceType", item.get("source_type"))
+            if "metadata" in item and item.get("metadata") is not None:
+                body_item["metadata"] = item.get("metadata")
+            if "priority" in item and item.get("priority") is not None:
+                body_item["priority"] = item.get("priority")
+            if created_at is not None:
+                body_item["createdAt"] = created_at
+            if updated_at is not None:
+                body_item["updatedAt"] = updated_at
+            if "documentId" in item or "document_id" in item:
+                body_item["documentId"] = item.get("documentId", item.get("document_id"))
+
+            normalized_items.append(body_item)
+
+        return self._send(
+            "POST",
+            DOCUMENTS_BATCH_PATH,
+            {"items": normalized_items},
+        )
+
+    def list_documents(
+        self,
+        *,
+        namespace: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> dict[str, Any]:
+        """List ingested documents."""
+        params: dict[str, Any] = {}
+        if namespace:
+            params["namespace"] = namespace
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+        return self._send_get(DOCUMENTS_LIST_PATH, params if params else None)
+
+    def get_document(
+        self,
+        *,
+        document_id: str,
+        namespace: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Get document details for a single document id."""
+        if not document_id or not isinstance(document_id, str):
+            raise ValueError("document_id is required and must be a string")
+        params: dict[str, Any] = {}
+        if namespace:
+            params["namespace"] = namespace
+        path = f"{DOCUMENTS_LIST_PATH}/{quote(document_id, safe='')}"
+        return self._send_get(path, params if params else None)
+
+    def delete_document(
+        self,
+        *,
+        document_id: str,
+        namespace: str,
+    ) -> dict[str, Any]:
+        """Delete a single ingested document."""
+        if not document_id or not isinstance(document_id, str):
+            raise ValueError("document_id is required and must be a string")
+        if not namespace or not isinstance(namespace, str):
+            raise ValueError("namespace is required and must be a string")
+
+        path = f"{DOCUMENTS_LIST_PATH}/{quote(document_id, safe='')}"
+        return self._send_delete(path, {"namespace": namespace})
+
+    def get_graph_snapshot(
+        self,
+        *,
+        namespace: Optional[str] = None,
+        mode: Optional[str] = None,
+        limit: Optional[int] = None,
+        seed_limit: Optional[int] = None,
+    ) -> dict[str, Any]:
+        """Get admin graph snapshot (backend-specific)."""
+        params: dict[str, Any] = {}
+        if namespace:
+            params["namespace"] = namespace
+        if mode:
+            params["mode"] = mode
+        if limit is not None:
+            params["limit"] = limit
+        if seed_limit is not None:
+            params["seed_limit"] = seed_limit
+        return self._send_get(
+            DOCUMENTS_GRAPH_SNAPSHOT_PATH,
+            params if params else None,
+        )
+
+    def query_memory_context(
+        self,
+        *,
+        query: str,
+        namespace: Optional[str] = None,
+        include_references: Optional[bool] = None,
+        max_chunks: Optional[int] = None,
+        document_ids: Optional[Sequence[str]] = None,
+        recall_only: Optional[bool] = None,
+        llm_query: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Query memory context via the mirrored /v1/memory/queries endpoint."""
+        if not query or not isinstance(query, str):
+            raise ValueError("query is required and must be a string")
+
+        body: dict[str, Any] = {"query": query}
+        if include_references is not None:
+            body["includeReferences"] = include_references
+        if namespace:
+            body["namespace"] = namespace
+        if max_chunks is not None:
+            body["maxChunks"] = max_chunks
+        if document_ids is not None:
+            body["documentIds"] = list(document_ids)
+        if recall_only is not None:
+            body["recallOnly"] = recall_only
+        if llm_query is not None:
+            body["llmQuery"] = llm_query
+
+        return self._send("POST", MEMORY_QUERIES_PATH, body)
+
+    def chat_memory_context(
+        self,
+        *,
+        messages: Sequence[dict[str, Any]],
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+    ) -> dict[str, Any]:
+        """Chat with memory context via the mirrored /v1/memory/conversations endpoint."""
+        if not messages or not isinstance(messages, (list, tuple)):
+            raise ValueError("messages must be a non-empty list of {role, content} dicts")
+        # Keep request shape aligned with the backend/TS SDK.
+        body: dict[str, Any] = {"messages": list(messages)}
+        if temperature is not None:
+            body["temperature"] = temperature
+        if max_tokens is not None:
+            body["maxTokens"] = max_tokens
+        return self._send("POST", MEMORY_CONVERSATIONS_PATH, body)
+
+    def record_interactions(
+        self,
+        *,
+        namespace: str,
+        entity_names: Sequence[str],
+        description: Optional[str] = None,
+        interaction_level: Optional[str] = None,
+        interaction_levels: Optional[Sequence[str]] = None,
+        timestamp: Optional[float] = None,
+    ) -> dict[str, Any]:
+        """Record entity interaction signals."""
+        if not namespace:
+            raise ValueError("namespace is required")
+        if not entity_names or not isinstance(entity_names, (list, tuple)):
+            raise ValueError("entity_names must be a non-empty list")
+
+        body: dict[str, Any] = {
+            "namespace": namespace,
+            "entityNames": list(entity_names),
+        }
+        if description is not None:
+            body["description"] = description
+        if interaction_level is not None:
+            body["interactionLevel"] = interaction_level
+        if interaction_levels is not None:
+            body["interactionLevels"] = list(interaction_levels)
+        if timestamp is not None:
+            body["timestamp"] = timestamp
+
+        return self._send("POST", MEMORY_INTERACTIONS_PATH, body)
+
+    def recall_thoughts(
+        self,
+        *,
+        namespace: Optional[str] = None,
+        max_chunks: Optional[int] = None,
+        temperature: Optional[float] = None,
+        randomness_seed: Optional[int] = None,
+        persist: Optional[bool] = None,
+        enable_prediction_check: Optional[bool] = None,
+        thought_prompt: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Generate reflective thoughts."""
+        body: dict[str, Any] = {}
+        if namespace:
+            body["namespace"] = namespace
+        if max_chunks is not None:
+            body["maxChunks"] = max_chunks
+        if temperature is not None:
+            body["temperature"] = temperature
+        if randomness_seed is not None:
+            body["randomnessSeed"] = randomness_seed
+        if persist is not None:
+            body["persist"] = persist
+        if enable_prediction_check is not None:
+            body["enablePredictionCheck"] = enable_prediction_check
+        if thought_prompt is not None:
+            body["thoughtPrompt"] = thought_prompt
+        return self._send("POST", MEMORY_THOUGHTS_PATH, body)
+
+    def get_ingestion_job(self, *, job_id: str) -> dict[str, Any]:
+        """Get memory ingestion job status by job id."""
+        if not job_id or not isinstance(job_id, str):
+            raise ValueError("job_id is required and must be a string")
+        path = f"{INGESTION_JOB_PATH_PREFIX}/{quote(job_id, safe='')}"
+        return self._send_get(path, None)
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
@@ -424,6 +901,30 @@ class TinyHumanMemoryClient:
             request.url,
             self._debug_headers(),
             body,
+        )
+        response = self._http.send(request)
+        return self._parse_response(response)
+
+    def _send_get(
+        self, path: str, params: Optional[dict[str, Any]] = None
+    ) -> dict[str, Any]:
+        request = self._http.build_request("GET", path, params=params)
+        logger.debug(
+            "HTTP GET %s headers=%s json=<none>",
+            request.url,
+            self._debug_headers(),
+        )
+        response = self._http.send(request)
+        return self._parse_response(response)
+
+    def _send_delete(
+        self, path: str, params: Optional[dict[str, Any]] = None
+    ) -> dict[str, Any]:
+        request = self._http.build_request("DELETE", path, params=params)
+        logger.debug(
+            "HTTP DELETE %s headers=%s json=<none>",
+            request.url,
+            self._debug_headers(),
         )
         response = self._http.send(request)
         return self._parse_response(response)

--- a/packages/sdk-python/tinyhumansai/types.py
+++ b/packages/sdk-python/tinyhumansai/types.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from typing import Any, Optional
 
 
-DEFAULT_BASE_URL = "https://api.tinyhumans.ai"
+DEFAULT_BASE_URL = "https://staging-api.alphahuman.xyz"
 BASE_URL_ENV = "TINYHUMANS_BASE_URL"
 
 


### PR DESCRIPTION
# Overview

Enhances the sdk-python package by adding new document and memory management endpoints to the Python example and client, along with expanded README documentation.

---

# Changes

- Update `packages/sdk-python/example.py` to add/demo new endpoints:
  - insert_document
  - insert_documents_batch
  - list_documents
  - get_document
  - delete_document
  - query_memory_context
  - chat_memory_context
  - record_interactions
  - recall_thoughts
  - sync_memory
  - recall_memories

- Improve error handling and logging in `packages/sdk-python/example.py` for new features

- Expand `packages/sdk-python/README.md` with usage and examples for new methods/endpoints

- Extend `packages/sdk-python/tinyhumansai/client.py` to support new API endpoints

- Update `packages/sdk-python/tinyhumansai/types.py` default base URL to staging API (for testing)

---

# Testing

- Run: `python example.py`
- From directory: `packages/sdk-python`

Required environment variables:
- `TINYHUMANS_TOKEN`
- `OPENAI_API_KEY` (only if using recall_with_llm)

Optional environment variables:
- `TINYHUMANS_WORKSPACE_ID`
- `TINYHUMANS_AGENT_ID` (required for sync_memory)

---

# Notes

- `sync_memory` is optional and backend-specific; it will be skipped unless workspace/agent environment variables are set
- `TINYHUMANS_BASE_URL` (if provided) overrides the staging default defined in `types.py`