### PR TITLE
fix(sdk-rust): ensure documentId is required for insert operations

### DIFF
--- a/packages/sdk-rust/examples/example_e2e.rs
+++ b/packages/sdk-rust/examples/example_e2e.rs
@@ -178,7 +178,7 @@ async fn main() {
         .map(|d| d.as_millis())
         .unwrap_or(0);
     let namespace = "sdk-rust-e2e".to_string();
-    let _single_doc_id = format!("sdk-rust-e2e-doc-single-{ts}");
+    let single_doc_id = format!("sdk-rust-e2e-doc-single-{ts}");
 
     let result = async {
         let insert_job_id = step1_insert_memory(&client, &namespace, &single_doc_id).await?;


### PR DESCRIPTION
- Updated `InsertMemoryParams`, `IngestDocumentParams`, and `BatchDocumentItem` to enforce `documentId` as a mandatory field.
- Added validation checks in `insert_memory`, `ingest_document`, and `ingest_documents_batch` to reject empty `documentId`.
- Updated related tests and examples to reflect these changes.