### PR TITLE
chore(deps): align rusqlite 0.40 + git2 0.21 with OpenHuman host

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,15 @@ exclude = [
 anyhow = "1"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
-git2 = "0.19"
+# Native-linking deps pinned to OpenHuman's versions so the host and the crate
+# link ONE bundled SQLite and ONE libgit2 (both are `links = "…"` crates; two
+# versions in one binary is a hard Cargo error). Keep in lockstep with the host
+# root Cargo.toml when either side bumps.
+git2 = { version = "0.21", default-features = false, features = ["vendored-libgit2"] }
 parking_lot = "0.12"
 rand = "0.8"
 regex = "1"
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/src/memory/diff/ledger.rs
+++ b/src/memory/diff/ledger.rs
@@ -366,7 +366,9 @@ impl Ledger {
         };
         Ok(Some(checkpoint_from_message(
             checkpoint_id,
-            tag.message().unwrap_or(""),
+            // git2 0.21: Tag::message() is Result<Option<&str>, _>; a non-UTF8
+            // or missing message degrades to an empty checkpoint body.
+            tag.message().ok().flatten().unwrap_or(""),
         )))
     }
 
@@ -375,8 +377,9 @@ impl Ledger {
         let pattern = format!("{CHECKPOINT_PREFIX}*");
         let names = self.repo.tag_names(Some(&pattern))?;
         let mut out = Vec::new();
-        // StringArray::iter() yields Option<&str>; drop non-utf8 names.
-        for name in names.iter().flatten() {
+        // git2 0.21: StringArray::iter() yields Result<Option<&str>, _>; keep
+        // only successfully-decoded utf8 names.
+        for name in names.iter().filter_map(|r| r.ok().flatten()) {
             if let Some(ckpt) = self.get_checkpoint(name)? {
                 out.push(ckpt);
             }
@@ -394,7 +397,8 @@ impl Ledger {
         let pattern = format!("{CHECKPOINT_PREFIX}*");
         let names = self.repo.tag_names(Some(&pattern))?;
         let mut deleted = 0u64;
-        for name in names.iter().flatten() {
+        // git2 0.21: StringArray::iter() yields Result<Option<&str>, _>.
+        for name in names.iter().filter_map(|r| r.ok().flatten()) {
             if let Some(ckpt) = self.get_checkpoint(name)? {
                 if ckpt.created_at_ms < older_than_ms {
                     self.repo.tag_delete(name)?;
@@ -545,7 +549,8 @@ fn oid_hash(oid: Oid) -> Option<String> {
 fn patch_text(diff: &git2::Diff, delta_idx: usize) -> Option<String> {
     let mut patch = git2::Patch::from_diff(diff, delta_idx).ok().flatten()?;
     let buf = patch.to_buf().ok()?;
-    let text = buf.as_str()?;
+    // git2 0.21: Buf::as_str() returns Result<&str, Utf8Error>.
+    let text = buf.as_str().ok()?;
     if text.trim().is_empty() {
         None
     } else {

--- a/src/memory/store/vectors/store.rs
+++ b/src/memory/store/vectors/store.rs
@@ -22,6 +22,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use anyhow::Context;
 use parking_lot::Mutex;
 use rusqlite::Connection;
 
@@ -369,7 +370,10 @@ impl VectorStore {
     /// Returns the number of entries in a namespace (or all if `None`).
     pub fn count(&self, namespace: Option<&str>) -> anyhow::Result<usize> {
         let conn = self.conn.lock();
-        let count: usize = match namespace {
+        // SQLite COUNT(*) is an i64; rusqlite (>= 0.33) no longer implements
+        // FromSql for usize, so read as i64 and convert. Overflow is impossible
+        // in practice but handled rather than silently truncated.
+        let count: i64 = match namespace {
             Some(ns) => conn.query_row(
                 "SELECT COUNT(*) FROM vectors WHERE namespace = ?1",
                 rusqlite::params![ns],
@@ -377,7 +381,7 @@ impl VectorStore {
             )?,
             None => conn.query_row("SELECT COUNT(*) FROM vectors", [], |row| row.get(0))?,
         };
-        Ok(count)
+        usize::try_from(count).context("vector count did not fit in usize")
     }
 
     /// Lists all distinct namespaces.


### PR DESCRIPTION
## Summary

Align the crate's native-linking dependencies with the OpenHuman host so the two can be built into one binary. This is the **first required PR** for the OpenHuman → TinyCortex memory migration (host tracking PR: tinyhumansai/openhuman#4516).

- Bump `rusqlite` `0.32` → `0.40` and `git2` `0.19` → `0.21` (with `vendored-libgit2`), matching the host pins (`rusqlite = "=0.40.0"`, `git2 = "0.21" + vendored-libgit2`).
- Adapt the API deltas the bumps introduce.

## Problem

`rusqlite` (→ `libsqlite3-sys`, `links = "sqlite3"`) and `git2` (→ `libgit2-sys`, `links = "git2"`) are native-linking crates. Cargo **hard-errors** if two versions of the same `links` crate appear in one dependency graph. OpenHuman pins `rusqlite =0.40.0 (bundled)` and `git2 0.21 (vendored-libgit2)`; TinyCortex pinned `rusqlite 0.32 (bundled)` / `git2 0.19`. With both bundling SQLite, the host could not even activate its `tinycortex` dependency — `cargo` refused to resolve the graph.

## Solution

- `rusqlite` `0.40`: `>= 0.33` dropped `FromSql for usize`, so `VectorStore::count` reads `COUNT(*)` as `i64` and converts via `usize::try_from(...).context(...)` (matches OpenHuman's own fix for the same call).
- `git2` `0.21` API deltas in `diff/ledger.rs`:
  - `Tag::message()` → `Result<Option<&str>, _>` — checkpoint tag reader degrades a missing/non-UTF8 message to `""`.
  - `StringArray::Iter::Item` → `Result<Option<&str>, _>` — the two tag-name loops use `filter_map(|r| r.ok().flatten())`.
  - `Buf::as_str()` → `Result<&str, Utf8Error>` — `patch_text` uses `.ok()?`.

## Validation

- `cargo check --all-targets` — clean.
- `cargo test --lib diff::` — 38 passed (exercises the changed checkpoint/tag-delete/patch code).
- Host root world (`tinyhumansai/openhuman`) `cargo check` with `tinycortex = "0.1"` active — exit 0, **no `multiple packages link to native library` error** (one bundled SQLite + one libgit2 confirmed).

## Notes

Keep these pins in lockstep with the host root `Cargo.toml` going forward — a comment in `Cargo.toml` records why. No behavior change beyond the dependency bump + API adaptation.
