### PR TITLE
chore: vendor tinyagents dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           # This job executes repo code (cargo build/test); don't persist the
           # token in git config.
           persist-credentials: false
+          submodules: true
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -70,6 +71,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+          submodules: true
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          submodules: true
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/tinyagents"]
+	path = vendor/tinyagents
+	url = https://github.com/tinyhumansai/tinyagents.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,8 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "tinyagents"
-version = "1.9.0"
-source = "git+https://github.com/senamakel/tinyagents?rev=8f75355#8f753557278e448c6c5bcf48ab8503505a47c663"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,9 @@ serde_json = "1"
 schemars = "1"
 sha2 = "0.10"
 thiserror = "2"
-tinyagents = { git = "https://github.com/senamakel/tinyagents", rev = "8f75355" }
+# Kept in lockstep with OpenHuman's vendored TinyAgents checkout. Initialize it
+# after cloning with `git submodule update --init vendor/tinyagents`.
+tinyagents = { version = "2", path = "vendor/tinyagents" }
 toml = "0.8"
 uuid = { version = "1", features = ["serde", "v4"] }
 walkdir = "2"


### PR DESCRIPTION
## Summary

- add TinyAgents as the `vendor/tinyagents` git submodule using the canonical public HTTPS repository
- replace the fork-pinned Git dependency with the vendored TinyAgents 2.0 path dependency
- initialize submodules in CI and release checkouts

## Why

TinyCortex previously fetched a specific TinyAgents fork commit directly through Cargo. Vendoring the canonical dependency matches the repository layout used by OpenHuman, makes the dependency source inspectable and editable in-tree, and avoids requiring fork-specific Git access.

The submodule is pinned to released TinyAgents 2.0.0 because it includes the embedding APIs TinyCortex consumes. The published 1.9.0 crate does not contain those APIs, so retaining a `version = "2"` fallback keeps `cargo package` verification and downstream crates.io consumption compatible.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo test` (1,132 passed; 1 ignored doc test)
- `cargo package --locked --allow-dirty`
- verified `vendor/tinyagents` is a mode `160000` gitlink at TinyAgents v2.0.0