### PR TITLE
fix(sync): shrink Gmail fetch page to avoid Composio 413

### DIFF
--- a/src/memory/sync/composio/gmail.rs
+++ b/src/memory/sync/composio/gmail.rs
@@ -29,7 +29,11 @@ impl GmailSyncPipeline {
             client,
             connection_id: connection_id.into(),
             max_pages: 10,
-            page_size: 50,
+            // Gmail fetches full message payloads (`include_payload: true`), so a
+            // large page overflows Composio's tool-response size cap with HTTP
+            // 413. 25 full messages/request stays comfortably under it; callers
+            // needing more throughput can raise it via `with_limits`.
+            page_size: 25,
             query_override: None,
         }
     }


### PR DESCRIPTION
## Summary

Follow-up to #71. Live Gmail sync failed with **HTTP 413 Payload Too Large** from
Composio's execute endpoint.

`GMAIL_FETCH_EMAILS` is called with `include_payload: true`, so each page returns
full message bodies. A 50-message page overflows Composio's tool-response size
cap. Verified against a real mailbox:

| `max_results` (`include_payload: true`) | Result |
| --- | --- |
| 50 | **HTTP 413** |
| 25 | HTTP 200 |
| 10 / 5 | HTTP 200 |

Lower the Gmail pipeline's default `page_size` from 50 to **25** (which also
matches the default per-toolkit item budget). Callers needing more throughput can
still raise it via `with_limits`.

## Testing
- `cargo test --features sync --test composio_sync_mock` — 12 passed.
- Live: `COMPOSIO_TOOLKITS=gmail cargo run --example composio_harness --features sync`
  → was `413`, now **PASS, 25 documents ingested**.

https://claude.ai/code/session_01AtynpEKn3QZJKZYvL8uDNR
