### PR TITLE
feat(sync): add Composio jira memory-sync pipeline

### DIFF
--- a/src/memory/sources/registry.rs
+++ b/src/memory/sources/registry.rs
@@ -48,6 +48,7 @@ pub fn memory_sync_defaults_for_toolkit(toolkit: &str) -> (Option<u32>, Option<u
         "slack" => (Some(50), Some(14)),
         "notion" => (Some(30), Some(30)),
         "linear" => (Some(50), Some(30)),
+        "jira" => (Some(50), Some(30)),
         "clickup" => (Some(50), Some(30)),
         "github" => (Some(50), Some(30)),
         // Generic fallback for any toolkit not listed above.

--- a/src/memory/sync/composio/mod.rs
+++ b/src/memory/sync/composio/mod.rs
@@ -14,6 +14,6 @@ pub use connect::{
 pub use gmail::GmailSyncPipeline;
 pub use orchestrator::{run_incremental_sync, IncrementalSource, PageFetch, SyncItem, SyncScope};
 pub use providers::{
-    ClickUpSyncPipeline, GitHubSyncPipeline, LinearSyncPipeline, NotionSyncPipeline,
-    SlackSearchBackfillPipeline, SlackSyncPipeline,
+    ClickUpSyncPipeline, GitHubSyncPipeline, JiraSyncPipeline, LinearSyncPipeline,
+    NotionSyncPipeline, SlackSearchBackfillPipeline, SlackSyncPipeline,
 };

--- a/src/memory/sync/composio/providers/jira.rs
+++ b/src/memory/sync/composio/providers/jira.rs
@@ -1,0 +1,249 @@
+//! Incremental Jira synchronization through Composio.
+//!
+//! Jira is a document-shaped source: each issue becomes one memory document,
+//! with its comments folded in via the `comment` field so no per-issue follow-up
+//! request is needed. The closest existing analogue is [`LinearSyncPipeline`] —
+//! both page an issue list ordered by "updated" and dedupe on a stable item id.
+//!
+//! Fetches use `JIRA_SEARCH_FOR_ISSUES_USING_JQL`. The response envelope varies
+//! between Jira Cloud's classic offset pagination (`startAt`/`maxResults`/
+//! `total`) and the enhanced token pagination (`nextPageToken`/`isLast`); both
+//! are handled by [`JiraSyncPipeline::next_page`].
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use super::common::{document, first_array, pick_str};
+use crate::memory::config::MemoryConfig;
+use crate::memory::sync::composio::{
+    run_incremental_sync, ActionExecutor, ComposioClient, IncrementalSource, PageFetch, SyncItem,
+    SyncScope,
+};
+use crate::memory::sync::state::SyncState;
+use crate::memory::sync::traits::{
+    SkillDocument, SyncContext, SyncOutcome, SyncPipeline, SyncPipelineKind,
+};
+
+const ACTION_SEARCH: &str = "JIRA_SEARCH_FOR_ISSUES_USING_JQL";
+
+/// Fields requested per issue. `comment` folds the issue's comments into the
+/// returned payload so each document carries its discussion without an extra
+/// round-trip. Kept explicit (rather than `*all`) to bound response size.
+const ISSUE_FIELDS: &[&str] = &[
+    "summary",
+    "description",
+    "status",
+    "assignee",
+    "reporter",
+    "priority",
+    "issuetype",
+    "project",
+    "labels",
+    "created",
+    "updated",
+    "comment",
+];
+
+/// Stable identifier candidates. The issue `key` (e.g. `PROJ-123`) is the
+/// natural, human-readable handle; the numeric `id` is the immutable fallback.
+/// Both are stable across syncs — never per-run — which keeps `document_id`
+/// (`jira:<id>`) usable as the upsert key.
+const ID_PATHS: &[&str] = &["key", "data.key", "id", "data.id"];
+
+const UPDATED_PATHS: &[&str] = &[
+    "fields.updated",
+    "data.fields.updated",
+    "updated",
+    "data.updated",
+];
+
+pub struct JiraSyncPipeline {
+    client: ComposioClient,
+    connection_id: String,
+    max_pages: usize,
+    page_size: usize,
+}
+
+impl JiraSyncPipeline {
+    pub fn new(client: ComposioClient, connection_id: impl Into<String>) -> Self {
+        Self {
+            client,
+            connection_id: connection_id.into(),
+            max_pages: 20,
+            page_size: 50,
+        }
+    }
+
+    pub fn with_limits(mut self, max_pages: usize, page_size: usize) -> Self {
+        self.max_pages = max_pages.max(1);
+        self.page_size = page_size.max(1);
+        self
+    }
+
+    /// Resolve the token for the next page from a search response.
+    ///
+    /// Prefers the enhanced-search `nextPageToken` (opaque string). Falls back
+    /// to classic offset pagination, encoding the next `startAt` as a numeric
+    /// string — [`Self::arguments`] disambiguates the two by parsing the token
+    /// as an integer (offset) or treating it as an opaque page token.
+    fn next_page(&self, data: &Value, page_len: usize) -> Option<String> {
+        if pointer_bool(data, &["/data/isLast", "/isLast", "/data/data/isLast"]) == Some(true) {
+            return None;
+        }
+        if let Some(token) = pointer_str(
+            data,
+            &[
+                "/data/nextPageToken",
+                "/nextPageToken",
+                "/data/data/nextPageToken",
+            ],
+        ) {
+            return Some(token);
+        }
+        let start_at =
+            pointer_i64(data, &["/data/startAt", "/startAt", "/data/data/startAt"]).unwrap_or(0);
+        let next_start = start_at + page_len as i64;
+        match pointer_i64(data, &["/data/total", "/total", "/data/data/total"]) {
+            // Classic envelope advertises the full result count.
+            Some(total) => (next_start < total).then(|| next_start.to_string()),
+            // No total: keep paging only while pages come back full.
+            None => (page_len >= self.page_size && page_len > 0).then(|| next_start.to_string()),
+        }
+    }
+}
+
+#[async_trait]
+impl SyncPipeline for JiraSyncPipeline {
+    fn id(&self) -> &str {
+        "composio:jira"
+    }
+    fn kind(&self) -> SyncPipelineKind {
+        SyncPipelineKind::Composio
+    }
+    async fn init(&self, _: &MemoryConfig, _: &SyncContext) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn tick(
+        &self,
+        config: &MemoryConfig,
+        context: &SyncContext,
+    ) -> anyhow::Result<SyncOutcome> {
+        run_incremental_sync(self, &self.client, &self.connection_id, config, context).await
+    }
+}
+
+#[async_trait]
+impl IncrementalSource for JiraSyncPipeline {
+    fn toolkit(&self) -> &'static str {
+        "jira"
+    }
+    fn action(&self) -> &'static str {
+        ACTION_SEARCH
+    }
+    fn max_pages(&self) -> usize {
+        self.max_pages
+    }
+    fn arguments(
+        &self,
+        _: &SyncScope,
+        _: &MemoryConfig,
+        _: &SyncState,
+        page: Option<&str>,
+    ) -> Value {
+        // "order by updated DESC" makes the engine's cursor-boundary detection
+        // (newest-first) valid; the stored cursor short-circuits already-synced
+        // issues on later runs.
+        let mut args = serde_json::json!({
+            "jql": "order by updated DESC",
+            "maxResults": self.page_size,
+            "fields": ISSUE_FIELDS,
+        });
+        if let Some(page) = page {
+            match page.parse::<i64>() {
+                Ok(start_at) => args["startAt"] = serde_json::json!(start_at),
+                Err(_) => args["nextPageToken"] = serde_json::json!(page),
+            }
+        }
+        args
+    }
+    fn extract_page(&self, data: &Value, _: Option<&str>) -> PageFetch {
+        let items = first_array(
+            data,
+            &[
+                "/data/issues",
+                "/issues",
+                "/data/data/issues",
+                "/data/results",
+                "/results",
+                "/data/items",
+                "/items",
+            ],
+        );
+        let next = self.next_page(data, items.len());
+        PageFetch { items, next }
+    }
+    fn dedup_key(&self, item: &Value) -> Option<String> {
+        let id = pick_str(item, ID_PATHS)?;
+        Some(match self.sort_cursor(item) {
+            Some(updated) => format!("{id}@{updated}"),
+            None => id,
+        })
+    }
+    fn sort_cursor(&self, item: &Value) -> Option<String> {
+        pick_str(item, UPDATED_PATHS)
+    }
+    async fn document(
+        &self,
+        _: &SyncScope,
+        connection_id: &str,
+        item: SyncItem,
+        _: &dyn ActionExecutor,
+        _: &mut SyncState,
+    ) -> anyhow::Result<SkillDocument> {
+        // Prefer the stable issue key/id; only fall back to the dedup key (which
+        // embeds the cursor) if the payload is missing every identifier.
+        let id = pick_str(&item.raw, ID_PATHS).unwrap_or_else(|| item.dedup_key.clone());
+        let title = pick_str(
+            &item.raw,
+            &["fields.summary", "data.fields.summary", "summary"],
+        )
+        .map(|summary| format!("{id}: {summary}"))
+        .unwrap_or_else(|| format!("Jira issue {id}"));
+        let content = serde_json::to_string_pretty(&item.raw)?;
+        // `document` sets `document_id = "jira:<id>"` and `metadata.taint =
+        // "external_sync"`, keeping the upsert key stable across re-syncs.
+        Ok(document(
+            "jira",
+            connection_id,
+            &id,
+            title,
+            content,
+            item.raw,
+        ))
+    }
+}
+
+fn pointer_str(data: &Value, pointers: &[&str]) -> Option<String> {
+    pointers
+        .iter()
+        .find_map(|pointer| data.pointer(pointer).and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn pointer_i64(data: &Value, pointers: &[&str]) -> Option<i64> {
+    pointers
+        .iter()
+        .find_map(|pointer| data.pointer(pointer).and_then(Value::as_i64))
+}
+
+fn pointer_bool(data: &Value, pointers: &[&str]) -> Option<bool> {
+    pointers
+        .iter()
+        .find_map(|pointer| data.pointer(pointer).and_then(Value::as_bool))
+}
+
+#[cfg(test)]
+#[path = "jira_tests.rs"]
+mod tests;

--- a/src/memory/sync/composio/providers/jira_tests.rs
+++ b/src/memory/sync/composio/providers/jira_tests.rs
@@ -1,0 +1,187 @@
+//! Unit tests for the Jira Composio sync pipeline.
+
+use async_trait::async_trait;
+use serde_json::json;
+
+use super::*;
+use crate::memory::config::{ComposioMode, ComposioSyncConfig, MemoryConfig};
+use crate::memory::sync::composio::client::{ActionExecutor, ExecuteResponse};
+use crate::memory::sync::composio::{ComposioClient, IncrementalSource, SyncItem, SyncScope};
+use crate::memory::sync::state::SyncState;
+
+/// Executor that must never be invoked: `document()` folds comments in from the
+/// list payload and issues no follow-up action.
+struct UnusedExecutor;
+
+#[async_trait]
+impl ActionExecutor for UnusedExecutor {
+    async fn execute(
+        &self,
+        action: &str,
+        _arguments: serde_json::Value,
+        _connection_id: Option<&str>,
+    ) -> anyhow::Result<ExecuteResponse> {
+        panic!("Jira document() must not call the executor (action: {action})");
+    }
+}
+
+fn test_composio_config() -> ComposioSyncConfig {
+    ComposioSyncConfig {
+        mode: ComposioMode::Direct,
+        base_url: "https://composio.test".into(),
+        api_key: None,
+        bearer_token: None,
+        entity_id: None,
+    }
+}
+
+fn pipeline() -> JiraSyncPipeline {
+    JiraSyncPipeline::new(ComposioClient::new(test_composio_config()), "jira-conn")
+}
+
+/// A representative single-page search response with an issue and folded-in
+/// comment, mirroring `JIRA_SEARCH_FOR_ISSUES_USING_JQL`.
+fn sample_page() -> serde_json::Value {
+    json!({
+        "data": {
+            "startAt": 0,
+            "maxResults": 50,
+            "total": 1,
+            "issues": [
+                {
+                    "id": "10001",
+                    "key": "PROJ-7",
+                    "fields": {
+                        "summary": "Login button misaligned",
+                        "updated": "2026-03-01T12:00:00.000+0000",
+                        "comment": {
+                            "comments": [
+                                {"body": "Reproduced on Safari", "author": {"displayName": "Sam"}}
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+    })
+}
+
+#[test]
+fn toolkit_and_action_are_stable() {
+    let pipeline = pipeline();
+    assert_eq!(pipeline.toolkit(), "jira");
+    assert_eq!(pipeline.action(), "JIRA_SEARCH_FOR_ISSUES_USING_JQL");
+    assert_eq!(pipeline.id(), "composio:jira");
+}
+
+#[test]
+fn extract_page_reads_issues_and_stops_at_last_offset_page() {
+    let pipeline = pipeline();
+    let fetched = pipeline.extract_page(&sample_page(), None);
+    assert_eq!(fetched.items.len(), 1);
+    assert_eq!(fetched.items[0]["key"], "PROJ-7");
+    // startAt(0) + 1 item == total(1), so there is no further page.
+    assert_eq!(fetched.next, None);
+}
+
+#[test]
+fn extract_page_advances_offset_when_more_remain() {
+    let pipeline = JiraSyncPipeline::new(ComposioClient::new(test_composio_config()), "jira-conn")
+        .with_limits(20, 2);
+    let data = json!({
+        "data": {
+            "startAt": 0,
+            "maxResults": 2,
+            "total": 5,
+            "issues": [{"key": "PROJ-1"}, {"key": "PROJ-2"}]
+        }
+    });
+    let fetched = pipeline.extract_page(&data, None);
+    assert_eq!(fetched.items.len(), 2);
+    assert_eq!(fetched.next.as_deref(), Some("2"));
+}
+
+#[test]
+fn extract_page_follows_enhanced_next_page_token() {
+    let pipeline = pipeline();
+    let data = json!({
+        "data": {
+            "nextPageToken": "opaque-cursor-abc",
+            "isLast": false,
+            "issues": [{"key": "PROJ-9"}]
+        }
+    });
+    let fetched = pipeline.extract_page(&data, None);
+    assert_eq!(fetched.next.as_deref(), Some("opaque-cursor-abc"));
+}
+
+#[test]
+fn extract_page_honors_is_last_flag() {
+    let pipeline = pipeline();
+    let data = json!({
+        "data": {"isLast": true, "issues": [{"key": "PROJ-9"}]}
+    });
+    assert_eq!(pipeline.extract_page(&data, None).next, None);
+}
+
+#[test]
+fn arguments_switch_between_offset_and_token_pagination() {
+    let pipeline = pipeline();
+    let config = MemoryConfig::new("/tmp/tinycortex-jira-test");
+    let state = SyncState::new("jira", "jira-conn");
+    let scope = SyncScope::flat();
+
+    let numeric = pipeline.arguments(&scope, &config, &state, Some("50"));
+    assert_eq!(numeric["startAt"], json!(50));
+    assert!(numeric.get("nextPageToken").is_none());
+    assert_eq!(numeric["jql"], "order by updated DESC");
+
+    let token = pipeline.arguments(&scope, &config, &state, Some("opaque-cursor"));
+    assert_eq!(token["nextPageToken"], "opaque-cursor");
+    assert!(token.get("startAt").is_none());
+}
+
+#[test]
+fn dedup_key_binds_id_to_updated_cursor() {
+    let pipeline = pipeline();
+    let item = &sample_page()["data"]["issues"][0];
+    assert_eq!(
+        pipeline.dedup_key(item).as_deref(),
+        Some("PROJ-7@2026-03-01T12:00:00.000+0000")
+    );
+    assert_eq!(
+        pipeline.sort_cursor(item).as_deref(),
+        Some("2026-03-01T12:00:00.000+0000")
+    );
+}
+
+#[tokio::test]
+async fn document_uses_stable_key_as_document_id() {
+    let pipeline = pipeline();
+    let raw = sample_page()["data"]["issues"][0].clone();
+    let item = SyncItem {
+        dedup_key: "PROJ-7@2026-03-01T12:00:00.000+0000".into(),
+        sort_cursor: Some("2026-03-01T12:00:00.000+0000".into()),
+        raw,
+    };
+    let mut state = SyncState::new("jira", "jira-conn");
+    let document = pipeline
+        .document(
+            &SyncScope::flat(),
+            "jira-conn",
+            item,
+            &UnusedExecutor,
+            &mut state,
+        )
+        .await
+        .unwrap();
+
+    // Stable, per-issue upsert key — no per-run suffix.
+    assert_eq!(document.document_id, "jira:PROJ-7");
+    assert_eq!(document.toolkit, "jira");
+    assert_eq!(document.namespace_skill_id, "jira");
+    assert_eq!(document.metadata["taint"], "external_sync");
+    assert!(document.title.contains("Login button misaligned"));
+    // Comments are folded into the document content.
+    assert!(document.content.contains("Reproduced on Safari"));
+}

--- a/src/memory/sync/composio/providers/mod.rs
+++ b/src/memory/sync/composio/providers/mod.rs
@@ -3,6 +3,7 @@
 mod clickup;
 mod common;
 mod github;
+mod jira;
 mod linear;
 mod notion;
 mod slack;
@@ -10,6 +11,7 @@ mod slack_parse;
 
 pub use clickup::ClickUpSyncPipeline;
 pub use github::GitHubSyncPipeline;
+pub use jira::JiraSyncPipeline;
 pub use linear::LinearSyncPipeline;
 pub use notion::NotionSyncPipeline;
 pub use slack::{SlackSearchBackfillPipeline, SlackSyncPipeline};

--- a/src/memory/sync/mod.rs
+++ b/src/memory/sync/mod.rs
@@ -19,7 +19,8 @@ pub use composio::{
     create_connection_link, generate_entity_id, get_connection_status, list_auth_configs,
     resolve_auth_config_id, status_is_active, status_is_terminal, ClickUpSyncPipeline,
     ComposioClient, ConnectionLink, EntityStore, GitHubSyncPipeline, GmailSyncPipeline,
-    LinearSyncPipeline, NotionSyncPipeline, SlackSearchBackfillPipeline, SlackSyncPipeline,
+    JiraSyncPipeline, LinearSyncPipeline, NotionSyncPipeline, SlackSearchBackfillPipeline,
+    SlackSyncPipeline,
 };
 pub use dispatcher::{SyncDispatcher, SyncRunResult};
 pub use github::GithubRepoSyncPipeline;


### PR DESCRIPTION
## Summary

Adds `JiraSyncPipeline`, the Composio memory-sync pipeline for the `jira` toolkit — the tinycortex-side deliverable of #81. Connecting a Jira source previously reported `ACTIVE` and then failed at sync with `tinycortex sync does not support toolkit 'jira'`; this implements the missing pipeline body so the slug becomes syncable.

## What it does

- Implements both `SyncPipeline` and `IncrementalSource` for `jira`.
- Fetches issues via `JIRA_SEARCH_FOR_ISSUES_USING_JQL` (JQL `order by updated DESC`), requesting an explicit field list that includes `comment`, so each issue's comments are **folded into the same document** with no per-issue follow-up request.
- Handles both response envelopes Jira Cloud returns: classic offset pagination (`startAt`/`maxResults`/`total`) and enhanced token pagination (`nextPageToken`/`isLast`). `arguments()` disambiguates the resumed token by parsing it as an integer offset or treating it as an opaque page token.
- Registers the pipeline through `providers/mod.rs` → `composio/mod.rs` → `memory/sync/mod.rs`, exactly like the six existing pipelines, and adds a conservative per-toolkit sync default for `jira`.

## Reference followed

Modeled on `LinearSyncPipeline` — the closest analogue (document-shaped issue list, dedupe on a stable item id, engine-driven cursor boundary). Shared `common::document` helper is reused for `SkillDocument` construction.

## Stable dedupe

`document_id = "jira:<issue key or id>"` with `metadata.taint = "external_sync"`. The issue key/id is stable across syncs — never a per-run id — keeping the upsert key idempotent (per the dedupe note in #81 and the earlier openhuman#4953 fix). Debug logging on the flow is content-free (no issue bodies/PII).

## Tests run

- `cargo fmt --all -- --check` — clean
- `cargo clippy --lib --features sync` — clean
- `cargo test --lib --features sync jira` — 8 new unit tests pass (`toolkit()`/`action()`, `extract_page()` over both pagination shapes + `isLast`, `dedup_key`, stable `document_id` from `document()`)
- `cargo test --features sync composio` + `cargo test --features sync --test composio_sync_mock` — 30 lib + 12 integration tests green, no regressions

## Follow-up (openhuman wiring — not in this PR)

Per #81, step 2 lands in `tinyhumansai/openhuman`: bump the `vendor/tinycortex` submodule, add the `sync.rs` selector arm, and register the `ComposioProvider` so `memory_sources.supported_toolkits` advertises the slug end to end.

Part of #81 (tinycortex pipeline body; openhuman wiring is the follow-up step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Jira synchronization, importing issues and comments into memory.
  * Supports incremental updates, pagination, duplicate prevention, and stable issue records.
  * Added Jira-specific default synchronization limits.

* **Tests**
  * Added coverage for Jira pagination, deduplication, metadata, comments, and stable document identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->