### PR TITLE
docs(persona): fix broken DigestObservation intra-doc link

### DIFF
--- a/src/memory/persona/retrieve.rs
+++ b/src/memory/persona/retrieve.rs
@@ -1,6 +1,6 @@
 //! Algorithmic (no-LLM) retrieval over the persona memory layer (doc 06).
 //!
-//! The persona pipeline folds distilled [`DigestObservation`]s into per-facet
+//! The persona pipeline folds distilled [`DigestObservation`](super::types::DigestObservation)s into per-facet
 //! flavoured trees, but it *also* persists every observation leaf verbatim as a
 //! `Document` chunk (`owner = "persona"`, `source_id = "persona/<facet>"`) — see
 //! [`reduce::fold_leaf`](super::reduce). Those leaves are the richest, most


### PR DESCRIPTION
One-line fix for the `Rust SDK` / Documentation CI failure present on `main` since #77: `retrieve.rs` links `[\`DigestObservation\`]` which is not in scope in that module. Qualified the link target. Verified with `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`.

Unblocks #119 (and any other PR) from inheriting this deterministic red check.