### PR TITLE
fix(deps): unify TinyAgents 2.1 source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "tinyagents"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ thiserror = "2"
 # Kept in lockstep with OpenHuman's vendored TinyAgents checkout. Downstream
 # workspaces can now replace this crates.io source with their own shared patch,
 # preserving a single TinyAgents trait identity across the dependency graph.
-tinyagents = "2.1"
+tinyagents = "=2.1.0"
 toml = "0.8"
 uuid = { version = "1", features = ["serde", "v4"] }
 walkdir = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,9 +64,10 @@ serde_json = "1"
 schemars = "1"
 sha2 = "0.10"
 thiserror = "2"
-# Kept in lockstep with OpenHuman's vendored TinyAgents checkout. Initialize it
-# after cloning with `git submodule update --init vendor/tinyagents`.
-tinyagents = { version = "2", path = "vendor/tinyagents" }
+# Kept in lockstep with OpenHuman's vendored TinyAgents checkout. Downstream
+# workspaces can now replace this crates.io source with their own shared patch,
+# preserving a single TinyAgents trait identity across the dependency graph.
+tinyagents = "2.1"
 toml = "0.8"
 uuid = { version = "1", features = ["serde", "v4"] }
 walkdir = "2"
@@ -100,6 +101,12 @@ dotenvy = "0.15"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
 wiremock = "0.6"
+
+# Standalone TinyCortex development still uses the pinned nested submodule.
+# Cargo ignores dependency-local patches when TinyCortex is consumed by a host,
+# allowing that host's crates.io patch to select its canonical TinyAgents copy.
+[patch.crates-io]
+tinyagents = { path = "vendor/tinyagents" }
 
 [[test]]
 name = "composio_sync_mock"


### PR DESCRIPTION
## Summary
- declare TinyAgents 2.1 from crates.io so downstream workspaces can apply one canonical patch
- keep standalone TinyCortex development on its nested pinned submodule via a local crates.io patch
- bump the nested development pin and lockfile to TinyAgents v2.1.0

This prevents OpenHuman from resolving TinyCortex against a second TinyAgents path package, which would split the shared trait universe.

## Validation
- `cargo fmt --all -- --check`
- `ulimit -n 4096; cargo test --manifest-path Cargo.toml --all-features -- --test-threads=2` (1384 unit + 18 integration/doc tests passed; 2 ignored)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated standalone development configuration to use the repository’s vendored `tinyagents` dependency.
  * Host applications can continue selecting their own canonical dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->