### PR TITLE
chore: align TinyAgents 2.1 and migration docs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[patch.crates-io]
+# Keep standalone TinyCortex builds offline-friendly and pinned to the nested
+# submodule. Embedding hosts ignore this config and may patch the same registry
+# requirement to their own TinyAgents checkout.
+tinyagents = { path = "vendor/tinyagents" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
             flags: --no-default-features --features git-diff
           - name: sync
             flags: --no-default-features --features sync
+          - name: persona
+            flags: --no-default-features --features persona
           - name: all features
             flags: --all-features
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "tinyagents"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,9 +64,11 @@ serde_json = "1"
 schemars = "1"
 sha2 = "0.10"
 thiserror = "2"
-# Kept in lockstep with OpenHuman's vendored TinyAgents checkout. Initialize it
-# after cloning with `git submodule update --init vendor/tinyagents`.
-tinyagents = { version = "2", path = "vendor/tinyagents" }
+# Kept in lockstep with OpenHuman's vendored TinyAgents checkout. Standalone
+# development resolves this requirement to `vendor/tinyagents` through
+# `.cargo/config.toml`; embedding hosts may supply their own crates.io patch so
+# the host and TinyCortex share one `EmbeddingModel` trait identity.
+tinyagents = "2.1"
 toml = "0.8"
 uuid = { version = "1", features = ["serde", "v4"] }
 walkdir = "2"

--- a/docs/openhuman-memory-engine-spec.md
+++ b/docs/openhuman-memory-engine-spec.md
@@ -2,7 +2,7 @@
 
 This document captures the OpenHuman memory engine as the target functional
 specification for TinyCortex. It is source-derived from
-`/Users/enamakel/work/tinyhumansai/openhuman-workflow/openhuman/src/openhuman`.
+the vendoring host's `src/openhuman/` tree.
 
 ## Scope
 

--- a/docs/openhuman-memory-migration.md
+++ b/docs/openhuman-memory-migration.md
@@ -4,15 +4,15 @@ This repository now has a Rust crate rooted at the repository root. The first
 migration target is the memory core: stable contracts, storage primitives, and
 testable in-process behavior before API or UI integrations.
 
-TinyCortex will not own memory sync. OpenHuman owns the sync module and
-decides when data is ingested on demand. TinyCortex should assume OpenHuman
-supplies source-scoped payloads or canonical ingest requests, then process them
-through TinyCortex contracts.
+TinyCortex owns the generic sync engine and provider pipelines behind its
+optional `sync` feature. OpenHuman retains scheduling, credentials, RPC,
+source-scope/redaction policy, and event-bus publishing, and supplies those
+product concerns through the sync adapter traits.
 
 ## Source Modules
 
-Use `/Users/enamakel/work/tinyhumansai/openhuman-workflow/openhuman/src/openhuman`
-as the current source checkout unless a later branch is chosen.
+Compare against the vendoring host's `src/openhuman/` tree; do not encode a
+developer-specific absolute checkout path in migration notes.
 
 - `memory/`: orchestration for query, remember, OpenHuman-triggered ingest, and
   RPC surfaces.

--- a/docs/openhuman-memory-migration.md
+++ b/docs/openhuman-memory-migration.md
@@ -41,8 +41,10 @@ The memory engine now lives under `src/memory/` as cohesive modules:
   `conversations/`, `archivist/`: specialized memory surfaces.
 
 Future host adapters should keep OpenHuman's layer rule: orchestration depends
-on storage, but storage does not depend upward on orchestration. The OpenHuman
-memory sync module remains outside this crate.
+on storage, but storage does not depend upward on orchestration. Generic sync
+fetch/pagination/canonical-record mechanics live in this crate behind injected
+traits; OpenHuman retains scheduling, credentials, source policy, event-bus
+translation, RPC, and product projections.
 
 ## Migration Order
 
@@ -50,8 +52,8 @@ memory sync module remains outside this crate.
 2. Port content and chunk storage behind the `MemoryStore` contract.
 3. Port tree IO and bucket-seal mechanics with storage injected by traits.
 4. Port queue workers only after persistence and deterministic drain tests exist.
-5. Add OpenHuman-facing on-demand ingest adapters; do not port the live sync
-   scheduler into TinyCortex.
+5. Add OpenHuman-facing ingest and sync adapters; keep the live scheduler in
+   OpenHuman.
 
 ## Port Status
 
@@ -79,9 +81,10 @@ are the current validation gates).
 | `conversations` | `memory_conversations` | JSONL transcript store, inverted index, persistence bus. |
 | `archivist` | `memory_archivist` | Conversation turns → one tree leaf (tool-JSON stripped). Tree-leaf sink injected. |
 
-Per the ownership boundary, the live sync runner, OAuth/webhook callbacks, and
-real LLM/embedding/network backends remain host-owned (OpenHuman) and are
-represented here as injectable traits. Known follow-ups: consolidate legacy
+Per the ownership boundary, the live sync scheduler, OAuth/webhook callbacks,
+credentials, and real LLM/embedding/network backends remain host-owned
+(OpenHuman) and are represented here as injectable traits. Generic provider
+pipelines and workspace reconciliation are crate-owned. Known follow-ups: consolidate legacy
 `score::store` entity-index helpers around `store::entity_index`; restore the
 deferred peripheral surfaces (tree `health`/`nlp`, retrieval RPC/fast paths,
 obsidian/wiki-git content, controller/tool registries) as host adapters land.

--- a/docs/openhuman-memory/README.md
+++ b/docs/openhuman-memory/README.md
@@ -10,7 +10,7 @@ owns the sync module and decides when data is ingested on demand. These specs
 describe the contracts TinyCortex exposes after OpenHuman supplies source data.
 
 Source checkout used for this pass:
-`/Users/enamakel/work/tinyhumansai/openhuman-workflow/openhuman/src/openhuman`.
+the vendoring host's `src/openhuman/` tree.
 
 ## Documents
 

--- a/docs/openhuman-memory/openhuman-code-reference.md
+++ b/docs/openhuman-memory/openhuman-code-reference.md
@@ -733,8 +733,8 @@ and wire-stable types for future adapters.
 3. Port goals, tool memory, entities, graph edges, and source validation first.
 4. Add storage traits around namespace documents, chunks, trees, vectors, KV,
    and archive records.
-5. Implement source reader shapes and optional sync adapters behind the
-   `SyncPipeline` trait; keep the live sync runner in OpenHuman.
+5. Implement source reader shapes and provider pipelines behind sync traits;
+   keep scheduling, credentials, policy, and product events in OpenHuman.
 6. Implement tree registry and tree IO before queue workers.
 7. Add queue dedupe keys, status transitions, and deferred outcomes.
 8. Add diff snapshots/checkpoints as a separate ledger.

--- a/docs/openhuman-memory/openhuman-code-reference.md
+++ b/docs/openhuman-memory/openhuman-code-reference.md
@@ -4,7 +4,7 @@ This document is a source-grounded reference for porting OpenHuman's memory
 engine into TinyCortex. It records the observed module responsibilities,
 contract types, operation boundaries, and implementation invariants from:
 
-`/Users/enamakel/work/tinyhumansai/openhuman-workflow/openhuman/src/openhuman`.
+the vendoring host's `src/openhuman/` tree.
 
 The goal is not to copy OpenHuman wholesale. TinyCortex should preserve the
 contracts and failure semantics first, then reimplement storage and workers with

--- a/docs/openhuman-memory/sources-registry-sync.md
+++ b/docs/openhuman-memory/sources-registry-sync.md
@@ -191,5 +191,5 @@ src/memory/ingest/canonicalize/
 
 Port order: source kind/types/validation, registry patch semantics, reader
 trait and static reader contracts, canonicalizer pure functions, then
-OpenHuman-facing on-demand ingest adapters. Do not port the live sync scheduler
-into TinyCortex.
+OpenHuman-facing ingest and sync adapters. The provider pipeline is crate-owned;
+the live scheduler, credentials, policy, and product events stay in OpenHuman.

--- a/docs/plan/05-openhuman-compat-matrix.md
+++ b/docs/plan/05-openhuman-compat-matrix.md
@@ -71,11 +71,10 @@ kind fields + sync budgets `types.rs:68-146`; discriminator validation
       reconciliation with `source_kind = raw_file` so interrupted syncs don't
       strand raw files (spec: sources-registry-sync.md §Raw Archive Coverage).
 
-Network fetchers (composio/github/rss/web/twitter) are **⏸ host-owned by
-design** — the TinyCortex boundary is the on-demand ingest call. Their only
-compatibility obligation is that the `reader_for` seam returns `None` so the
-host routes them through its own sync runner. **Do not port the live sync
-scheduler.**
+Generic Composio provider fetch/pagination pipelines are crate-owned behind
+injected network and persistence traits. Provider credentials, the scheduler,
+source policy, RPC, events, and non-Composio product integrations remain
+host-owned. **Do not port the live sync scheduler.**
 
 ---
 


### PR DESCRIPTION
## Summary

- Aligns TinyCortex on TinyAgents 2.1 and refreshes the lockfile and nested vendor pointer.
- Adds a standalone crates.io patch so a direct TinyCortex checkout consistently uses its reviewed nested TinyAgents source.
- Adds the persona feature to the CI feature matrix.
- Corrects migration documentation to reflect that the generic sync engine is crate-owned while OpenHuman retains scheduling, credentials, RPC, policy, and event-bus integration.

## API Or Behavior Changes

No TinyCortex API behavior changes. This unifies dependency identity, expands CI coverage, and corrects ownership documentation.

## Tests

Focused validation completed:

- cargo test --no-default-features --features persona -- --test-threads=1 (1284 unit tests plus integration and doc tests passed)
- OpenHuman CI Full TinyCortex Memory Tests passed in run 29925645209

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test`

## Documentation

Updated the OpenHuman memory-engine migration, compatibility, code-reference, and sync ownership documents in this repository.
