### PR TITLE
feat(sync): add Composio Todoist memory-sync pipeline

### DIFF
--- a/src/memory/sync/composio/mod.rs
+++ b/src/memory/sync/composio/mod.rs
@@ -15,5 +15,5 @@ pub use gmail::GmailSyncPipeline;
 pub use orchestrator::{run_incremental_sync, IncrementalSource, PageFetch, SyncItem, SyncScope};
 pub use providers::{
     ClickUpSyncPipeline, GitHubSyncPipeline, LinearSyncPipeline, NotionSyncPipeline,
-    SlackSearchBackfillPipeline, SlackSyncPipeline,
+    SlackSearchBackfillPipeline, SlackSyncPipeline, TodoistSyncPipeline,
 };

--- a/src/memory/sync/composio/providers/mod.rs
+++ b/src/memory/sync/composio/providers/mod.rs
@@ -7,9 +7,11 @@ mod linear;
 mod notion;
 mod slack;
 mod slack_parse;
+mod todoist;
 
 pub use clickup::ClickUpSyncPipeline;
 pub use github::GitHubSyncPipeline;
 pub use linear::LinearSyncPipeline;
 pub use notion::NotionSyncPipeline;
 pub use slack::{SlackSearchBackfillPipeline, SlackSyncPipeline};
+pub use todoist::TodoistSyncPipeline;

--- a/src/memory/sync/composio/providers/todoist.rs
+++ b/src/memory/sync/composio/providers/todoist.rs
@@ -98,18 +98,24 @@ impl IncrementalSource for TodoistSyncPipeline {
         serde_json::json!({})
     }
     fn extract_page(&self, data: &Value, _: Option<&str>) -> PageFetch {
-        PageFetch {
-            items: first_array(
+        // Todoist's active-tasks response is sometimes the bare task array
+        // (already unwrapped from the Composio `data` envelope by the client)
+        // and sometimes wrapped under `tasks`/`items`. Handle the top-level
+        // array first, then the wrapped shapes.
+        let items = data.as_array().cloned().unwrap_or_else(|| {
+            first_array(
                 data,
                 &[
                     "/data/tasks",
                     "/tasks",
                     "/data/items",
                     "/items",
-                    "/data",
                     "/data/data",
                 ],
-            ),
+            )
+        });
+        PageFetch {
+            items,
             // Todoist active tasks are returned as a single unpaginated array.
             next: None,
         }
@@ -147,7 +153,17 @@ impl IncrementalSource for TodoistSyncPipeline {
             &["content", "data.content", "title", "data.title"],
         )
         .unwrap_or_else(|| format!("Todoist task {id}"));
-        let content = serde_json::to_string_pretty(&item.raw)?;
+        // A Todoist task's meaningful text is its `content` (title line) plus an
+        // optional `description`; store that as the document body so retrieval
+        // embeds the task text, not JSON syntax. Fall back to the raw payload
+        // only when the task carries no content field.
+        let content = match pick_str(&item.raw, &["content", "data.content"]) {
+            Some(text) => match pick_str(&item.raw, &["description", "data.description"]) {
+                Some(desc) if !desc.trim().is_empty() => format!("{text}\n\n{desc}"),
+                _ => text,
+            },
+            None => serde_json::to_string_pretty(&item.raw)?,
+        };
         Ok(document(
             "todoist",
             connection_id,
@@ -160,12 +176,51 @@ impl IncrementalSource for TodoistSyncPipeline {
 }
 
 /// Stable content fingerprint of a task payload, used as the freshness half of
-/// the dedup key. Deterministic for a given payload (`DefaultHasher` has a fixed
-/// seed and `serde_json` serializes map keys in sorted order), so an unchanged
-/// task always hashes the same and any edit changes the hash.
+/// the dedup key. Computed as FNV-1a over a canonical serialization (object keys
+/// sorted recursively). The key is **persisted** in `SyncState`, so the hash
+/// must be stable across Rust toolchains and independent of `serde_json` map
+/// ordering — `DefaultHasher` guarantees neither, and an unstable value would
+/// silently re-ingest every task on a toolchain bump.
 fn payload_fingerprint(item: &Value) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    item.to_string().hash(&mut hasher);
-    hasher.finish()
+    let mut canonical = String::new();
+    write_canonical(item, &mut canonical);
+    // FNV-1a 64-bit — a fixed, specified algorithm.
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in canonical.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+/// Serialize `value` with object keys sorted recursively so the byte stream is
+/// canonical regardless of map insertion order.
+fn write_canonical(value: &Value, out: &mut String) {
+    match value {
+        Value::Object(map) => {
+            out.push('{');
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort_unstable();
+            for (index, key) in keys.iter().enumerate() {
+                if index > 0 {
+                    out.push(',');
+                }
+                out.push_str(&serde_json::to_string(key).unwrap_or_default());
+                out.push(':');
+                write_canonical(&map[*key], out);
+            }
+            out.push('}');
+        }
+        Value::Array(items) => {
+            out.push('[');
+            for (index, item) in items.iter().enumerate() {
+                if index > 0 {
+                    out.push(',');
+                }
+                write_canonical(item, out);
+            }
+            out.push(']');
+        }
+        other => out.push_str(&other.to_string()),
+    }
 }

--- a/src/memory/sync/composio/providers/todoist.rs
+++ b/src/memory/sync/composio/providers/todoist.rs
@@ -1,0 +1,164 @@
+use async_trait::async_trait;
+use serde_json::Value;
+
+use super::common::{document, first_array, pick_str};
+use crate::memory::config::MemoryConfig;
+use crate::memory::sync::composio::{
+    run_incremental_sync, ActionExecutor, ComposioClient, IncrementalSource, PageFetch, SyncItem,
+    SyncScope,
+};
+use crate::memory::sync::state::SyncState;
+use crate::memory::sync::traits::{
+    SkillDocument, SyncContext, SyncOutcome, SyncPipeline, SyncPipelineKind,
+};
+
+const ACTION_GET_ALL_TASKS: &str = "TODOIST_GET_ALL_TASKS";
+
+/// Incremental Todoist synchronization through Composio.
+///
+/// Todoist tasks are self-contained records (stable id + `created_at`
+/// timestamp), so this follows the document-shaped pattern
+/// (`LinearSyncPipeline`) rather than the message-shaped one: a single list
+/// action, content taken directly from the task payload with no secondary
+/// fetch. Todoist's active-tasks endpoint returns a plain array and is not
+/// paginated, so there is no server-side incremental filter; the orchestrator's
+/// client-side dedup (`synced_ids`) plus the `created_at` sort cursor drive
+/// incremental behavior.
+pub struct TodoistSyncPipeline {
+    client: ComposioClient,
+    connection_id: String,
+    max_pages: usize,
+    // Todoist active-tasks is unpaginated, so `page_size` is stored only to keep
+    // the constructor signature parallel to sibling pipelines; it is unused.
+    page_size: usize,
+}
+
+impl TodoistSyncPipeline {
+    pub fn new(client: ComposioClient, connection_id: impl Into<String>) -> Self {
+        Self {
+            client,
+            connection_id: connection_id.into(),
+            max_pages: 1,
+            page_size: 50,
+        }
+    }
+
+    pub fn with_limits(mut self, max_pages: usize, _page_size: usize) -> Self {
+        self.max_pages = max_pages.max(1);
+        // Todoist active-tasks is unpaginated; retain the sibling signature but
+        // ignore the requested page size.
+        self.page_size = _page_size;
+        self
+    }
+}
+
+#[async_trait]
+impl SyncPipeline for TodoistSyncPipeline {
+    fn id(&self) -> &str {
+        "composio:todoist"
+    }
+    fn kind(&self) -> SyncPipelineKind {
+        SyncPipelineKind::Composio
+    }
+    async fn init(&self, _: &MemoryConfig, _: &SyncContext) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn tick(
+        &self,
+        config: &MemoryConfig,
+        context: &SyncContext,
+    ) -> anyhow::Result<SyncOutcome> {
+        run_incremental_sync(self, &self.client, &self.connection_id, config, context).await
+    }
+}
+
+#[async_trait]
+impl IncrementalSource for TodoistSyncPipeline {
+    fn toolkit(&self) -> &'static str {
+        "todoist"
+    }
+    fn action(&self) -> &'static str {
+        ACTION_GET_ALL_TASKS
+    }
+    fn max_pages(&self) -> usize {
+        self.max_pages
+    }
+    fn stop_on_empty_pending(&self) -> bool {
+        true
+    }
+    fn server_side_depth(&self) -> bool {
+        false
+    }
+    fn arguments(
+        &self,
+        _: &SyncScope,
+        _: &MemoryConfig,
+        _: &SyncState,
+        _page: Option<&str>,
+    ) -> Value {
+        // Todoist "get all active tasks" needs no required arguments and ignores
+        // pagination; do not invent a page token.
+        serde_json::json!({})
+    }
+    fn extract_page(&self, data: &Value, _: Option<&str>) -> PageFetch {
+        PageFetch {
+            items: first_array(
+                data,
+                &[
+                    "/data/tasks",
+                    "/tasks",
+                    "/data/items",
+                    "/items",
+                    "/data",
+                    "/data/data",
+                ],
+            ),
+            // Todoist active tasks are returned as a single unpaginated array.
+            next: None,
+        }
+    }
+    fn dedup_key(&self, item: &Value) -> Option<String> {
+        let id = pick_str(item, &["id", "data.id", "task_id", "data.task_id"])?;
+        Some(match self.sort_cursor(item) {
+            Some(created) => format!("{id}@{created}"),
+            None => id,
+        })
+    }
+    fn sort_cursor(&self, item: &Value) -> Option<String> {
+        pick_str(
+            item,
+            &[
+                "created_at",
+                "data.created_at",
+                "added_at",
+                "data.added_at",
+                "createdAt",
+            ],
+        )
+    }
+    async fn document(
+        &self,
+        _: &SyncScope,
+        connection_id: &str,
+        item: SyncItem,
+        _: &dyn ActionExecutor,
+        _: &mut SyncState,
+    ) -> anyhow::Result<SkillDocument> {
+        let id = pick_str(&item.raw, &["id", "data.id", "task_id", "data.task_id"])
+            .unwrap_or_else(|| item.dedup_key.clone());
+        let title = pick_str(
+            &item.raw,
+            &["content", "data.content", "title", "data.title"],
+        )
+        .unwrap_or_else(|| format!("Todoist task {id}"));
+        let content = serde_json::to_string_pretty(&item.raw)?;
+        Ok(document(
+            "todoist",
+            connection_id,
+            &id,
+            title,
+            content,
+            item.raw,
+        ))
+    }
+}

--- a/src/memory/sync/composio/providers/todoist.rs
+++ b/src/memory/sync/composio/providers/todoist.rs
@@ -21,16 +21,15 @@ const ACTION_GET_ALL_TASKS: &str = "TODOIST_GET_ALL_TASKS";
 /// (`LinearSyncPipeline`) rather than the message-shaped one: a single list
 /// action, content taken directly from the task payload with no secondary
 /// fetch. Todoist's active-tasks endpoint returns a plain array and is not
-/// paginated, so there is no server-side incremental filter; the orchestrator's
-/// client-side dedup (`synced_ids`) plus the `created_at` sort cursor drive
-/// incremental behavior.
+/// paginated, so there is no server-side incremental filter, and a task carries
+/// no modification timestamp. Incremental behavior is therefore driven by the
+/// orchestrator's client-side dedup (`synced_ids`) keyed on a payload
+/// fingerprint (see [`dedup_key`](Self::dedup_key)) — an unchanged task is
+/// skipped, while any edit re-ingests.
 pub struct TodoistSyncPipeline {
     client: ComposioClient,
     connection_id: String,
     max_pages: usize,
-    // Todoist active-tasks is unpaginated, so `page_size` is stored only to keep
-    // the constructor signature parallel to sibling pipelines; it is unused.
-    page_size: usize,
 }
 
 impl TodoistSyncPipeline {
@@ -39,15 +38,13 @@ impl TodoistSyncPipeline {
             client,
             connection_id: connection_id.into(),
             max_pages: 1,
-            page_size: 50,
         }
     }
 
     pub fn with_limits(mut self, max_pages: usize, _page_size: usize) -> Self {
         self.max_pages = max_pages.max(1);
-        // Todoist active-tasks is unpaginated; retain the sibling signature but
-        // ignore the requested page size.
-        self.page_size = _page_size;
+        // Todoist active-tasks is unpaginated; the sibling `page_size` argument
+        // is accepted for signature parity but has no effect.
         self
     }
 }
@@ -119,22 +116,21 @@ impl IncrementalSource for TodoistSyncPipeline {
     }
     fn dedup_key(&self, item: &Value) -> Option<String> {
         let id = pick_str(item, &["id", "data.id", "task_id", "data.task_id"])?;
-        Some(match self.sort_cursor(item) {
-            Some(created) => format!("{id}@{created}"),
-            None => id,
-        })
+        // Todoist tasks have no modification timestamp, so `created_at` (which is
+        // immutable) would never change and edited tasks would never re-ingest.
+        // Key on a fingerprint of the task payload instead: any change to
+        // content/due/project yields a new key and re-ingests, while an
+        // unchanged task keeps its key and is deduped.
+        Some(format!("{id}@{}", payload_fingerprint(item)))
     }
-    fn sort_cursor(&self, item: &Value) -> Option<String> {
-        pick_str(
-            item,
-            &[
-                "created_at",
-                "data.created_at",
-                "added_at",
-                "data.added_at",
-                "createdAt",
-            ],
-        )
+    fn sort_cursor(&self, _item: &Value) -> Option<String> {
+        // Todoist active tasks have no modification timestamp and the endpoint
+        // is unpaginated, so there is no meaningful sort cursor. Returning None
+        // is deliberate: the orchestrator's cursor-boundary short-circuit keys
+        // on `sort_cursor`, and using the immutable `created_at` would halt the
+        // scan (and skip re-ingest) for an edited task created before the
+        // persisted cursor. Freshness is handled entirely by `dedup_key`.
+        None
     }
     async fn document(
         &self,
@@ -161,4 +157,15 @@ impl IncrementalSource for TodoistSyncPipeline {
             item.raw,
         ))
     }
+}
+
+/// Stable content fingerprint of a task payload, used as the freshness half of
+/// the dedup key. Deterministic for a given payload (`DefaultHasher` has a fixed
+/// seed and `serde_json` serializes map keys in sorted order), so an unchanged
+/// task always hashes the same and any edit changes the hash.
+fn payload_fingerprint(item: &Value) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    item.to_string().hash(&mut hasher);
+    hasher.finish()
 }

--- a/src/memory/sync/mod.rs
+++ b/src/memory/sync/mod.rs
@@ -20,6 +20,7 @@ pub use composio::{
     resolve_auth_config_id, status_is_active, status_is_terminal, ClickUpSyncPipeline,
     ComposioClient, ConnectionLink, EntityStore, GitHubSyncPipeline, GmailSyncPipeline,
     LinearSyncPipeline, NotionSyncPipeline, SlackSearchBackfillPipeline, SlackSyncPipeline,
+    TodoistSyncPipeline,
 };
 pub use dispatcher::{SyncDispatcher, SyncRunResult};
 pub use github::GithubRepoSyncPipeline;

--- a/tests/composio_sync_mock.rs
+++ b/tests/composio_sync_mock.rs
@@ -415,6 +415,48 @@ async fn todoist_lists_tasks_dedupes_and_is_idempotent() {
     assert_eq!(captures.documents.lock().unwrap().len(), 2);
 }
 
+struct TodoistEditedTask(AtomicUsize);
+
+impl Respond for TodoistEditedTask {
+    fn respond(&self, _: &Request) -> ResponseTemplate {
+        // Same task id, edited content on the second tick — no timestamp change
+        // (Todoist tasks have none), so only the payload fingerprint differs.
+        let content = if self.0.fetch_add(1, Ordering::SeqCst) == 0 {
+            "Draft proposal"
+        } else {
+            "Draft proposal (revised)"
+        };
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "successful": true,
+            "data": {"tasks": [{"id": "t9", "content": content, "created_at": "2026-05-05T00:00:00Z"}]}
+        }))
+    }
+}
+
+#[tokio::test]
+async fn todoist_reingests_edited_task_without_timestamp_change() {
+    let server = MockServer::start().await;
+    Mock::given(path("/tools/execute/TODOIST_GET_ALL_TASKS"))
+        .respond_with(TodoistEditedTask(AtomicUsize::new(0)))
+        .mount(&server)
+        .await;
+    let (captures, context) = test_context();
+    let pipeline = TodoistSyncPipeline::new(
+        ComposioClient::new(direct_config(server.uri(), "key")),
+        "todoist-edit-conn",
+    );
+
+    let first = pipeline.tick(&test_config(), &context).await.unwrap();
+    assert_eq!(first.records_ingested, 1);
+    // Second tick: identical id, edited content → new payload fingerprint →
+    // re-ingested (would be silently skipped if keyed on immutable created_at).
+    let second = pipeline.tick(&test_config(), &context).await.unwrap();
+    assert_eq!(second.records_ingested, 1);
+    let docs = captures.documents.lock().unwrap();
+    assert_eq!(docs.last().unwrap().document_id, "todoist:t9");
+    assert!(docs.last().unwrap().content.contains("revised"));
+}
+
 #[tokio::test]
 async fn notion_fetches_markdown_and_counts_both_requests() {
     let server = MockServer::start().await;

--- a/tests/composio_sync_mock.rs
+++ b/tests/composio_sync_mock.rs
@@ -9,7 +9,7 @@ use tinycortex::memory::sync::{
     ClickUpSyncPipeline, ComposioClient, GitHubSyncPipeline, GmailSyncPipeline, LinearSyncPipeline,
     NotionSyncPipeline, SkillDocSink, SkillDocument, SlackSearchBackfillPipeline,
     SlackSyncPipeline, SyncContext, SyncEvent, SyncEventSink, SyncPipeline, SyncStage, SyncState,
-    SyncStateStore,
+    SyncStateStore, TodoistSyncPipeline,
 };
 use wiremock::matchers::{body_partial_json, header, method, path, path_regex};
 use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
@@ -378,6 +378,40 @@ async fn linear_resolves_viewer_and_follows_graphql_cursor() {
     );
     let outcome = pipeline.tick(&test_config(), &context).await.unwrap();
     assert_eq!(outcome.records_ingested, 2);
+    assert_eq!(captures.documents.lock().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn todoist_lists_tasks_dedupes_and_is_idempotent() {
+    let server = MockServer::start().await;
+    Mock::given(path("/tools/execute/TODOIST_GET_ALL_TASKS"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "successful": true,
+            "data": {"tasks": [
+                {"id": "t1", "content": "Write report", "created_at": "2026-05-01T00:00:00Z"},
+                {"id": "t2", "content": "Review PR", "created_at": "2026-05-02T00:00:00Z"}
+            ]}
+        })))
+        .mount(&server)
+        .await;
+    let (captures, context) = test_context();
+    let pipeline = TodoistSyncPipeline::new(
+        ComposioClient::new(direct_config(server.uri(), "key")),
+        "todoist-conn",
+    );
+    let outcome = pipeline.tick(&test_config(), &context).await.unwrap();
+    assert_eq!(outcome.records_ingested, 2);
+    {
+        let documents = captures.documents.lock().unwrap();
+        assert_eq!(documents[0].document_id, "todoist:t1");
+        assert_eq!(documents[0].title, "Write report");
+        assert!(documents
+            .iter()
+            .all(|doc| doc.metadata["taint"] == "external_sync"));
+    }
+
+    let second = pipeline.tick(&test_config(), &context).await.unwrap();
+    assert_eq!(second.records_ingested, 0);
     assert_eq!(captures.documents.lock().unwrap().len(), 2);
 }
 

--- a/tests/composio_sync_mock.rs
+++ b/tests/composio_sync_mock.rs
@@ -405,6 +405,8 @@ async fn todoist_lists_tasks_dedupes_and_is_idempotent() {
         let documents = captures.documents.lock().unwrap();
         assert_eq!(documents[0].document_id, "todoist:t1");
         assert_eq!(documents[0].title, "Write report");
+        // The document body is the task text, not JSON.
+        assert_eq!(documents[0].content, "Write report");
         assert!(documents
             .iter()
             .all(|doc| doc.metadata["taint"] == "external_sync"));
@@ -413,6 +415,32 @@ async fn todoist_lists_tasks_dedupes_and_is_idempotent() {
     let second = pipeline.tick(&test_config(), &context).await.unwrap();
     assert_eq!(second.records_ingested, 0);
     assert_eq!(captures.documents.lock().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn todoist_reads_tasks_from_bare_data_array() {
+    // Composio sometimes returns the Todoist list as `data: [...]` directly
+    // rather than `data: { tasks: [...] }`; the pipeline must handle both.
+    let server = MockServer::start().await;
+    Mock::given(path("/tools/execute/TODOIST_GET_ALL_TASKS"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "successful": true,
+            "data": [
+                {"id": "t5", "content": "Ship release", "created_at": "2026-05-05T00:00:00Z"}
+            ]
+        })))
+        .mount(&server)
+        .await;
+    let (captures, context) = test_context();
+    let pipeline = TodoistSyncPipeline::new(
+        ComposioClient::new(direct_config(server.uri(), "key")),
+        "todoist-bare-conn",
+    );
+    let outcome = pipeline.tick(&test_config(), &context).await.unwrap();
+    assert_eq!(outcome.records_ingested, 1);
+    let docs = captures.documents.lock().unwrap();
+    assert_eq!(docs[0].document_id, "todoist:t5");
+    assert_eq!(docs[0].content, "Ship release");
 }
 
 struct TodoistEditedTask(AtomicUsize);


### PR DESCRIPTION
## Summary

Adds **`TodoistSyncPipeline`** for the Composio **`todoist`** toolkit, document-shaped. Previously advertised but unsyncable (tinyhumansai/tinycortex#106).

- Single action `TODOIST_GET_ALL_TASKS` (verified against `catalogs_productivity.rs`). Todoist's active-tasks endpoint returns a plain array and is **unpaginated**, so this is an honest single-fetch — no invented page-token params; `extract_page` handles both the `data.tasks` wrapper and a bare `data` array. Task text comes from `content`; stable upsert key `todoist:<id>`, `taint = external_sync`, content-free logging.
- Registered through the three mod files.

Branch name mentions Dropbox, but Dropbox is **deferred**: the curated catalog exposes no clean `list_folder`-style enumeration action, so shipping it would require guessing an action schema. Only Todoist is included here — no Dropbox stub was committed.

Pipeline body only (step 1 of 2); openhuman wiring closes the issue end to end.

## API Or Behavior Changes

One new public `SyncPipeline` type exported from `memory::sync`. Additive.

## Tests

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` (all-features green; new mock test asserts task ingestion from `content`, stable `document_id`, and idempotent re-sync via global dedup)

## Documentation

Module/item docs, including a note that `page_size` is unused (Todoist active-tasks is unpaginated). No external docs needed.

Part of tinyhumansai/tinycortex#95 · tracker tinyhumansai/tinycortex#106


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Todoist synchronization for importing active tasks.
  * Supports task titles, descriptions, and alternate response formats.
  * Preserves updates, avoids duplicates, and supports configurable synchronization limits.
  * Exposes Todoist integration metadata.

* **Bug Fixes**
  * Updated tasks are re-imported even when timestamps remain unchanged.

* **Tests**
  * Added coverage for ingestion, deduplication, external-sync tagging, alternate responses, and content updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->